### PR TITLE
Fix for issue #2 remove need for encrypted credentials on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ cache: bundler
 os:
   - linux
   - osx
-before_install:
-- openssl aes-256-cbc -K $encrypted_4e4ac21e4bd9_key -iv $encrypted_4e4ac21e4bd9_iv
-  -in test/test_config.yml.enc -out test/test_config.yml -d
+# before_install:
+# - openssl aes-256-cbc -K $encrypted_4e4ac21e4bd9_key -iv $encrypted_4e4ac21e4bd9_iv
+#   -in test/test_config.yml.enc -out test/test_config.yml -d

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,11 @@ require 'respoke'
 
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
-TestConfig = Hashie::Mash.load(File.expand_path('test_config.yml', __dir__))
+TestConfig = if ENV['TRAVIS']
+  Hashie::Mash.new(app_id: 'APP_ID', app_secret: 'APP_SECRET', role_id: 'ROLE_ID')
+else
+  Hashie::Mash.load(File.expand_path('test_config.yml', __dir__))
+end
 
 VCR.configure do |config|
   # Due to a bug in VCR faraday middleware we must use webmock. A fix has been


### PR DESCRIPTION
Since all tests are run using VCR - having valid respoke credentials on travis isn't necessary
