### PR TITLE
Add Respoke-SDK header to all requests

### DIFF
--- a/lib/respoke/client.rb
+++ b/lib/respoke/client.rb
@@ -1,6 +1,6 @@
 require 'faraday'
 require 'faraday_middleware'
-
+require 'respoke/version'
 require 'respoke/errors'
 require 'respoke/response'
 
@@ -253,7 +253,10 @@ class Respoke::Client
   def connection
     @connection ||= Faraday.new(
       url: @base_url,
-      headers: { :'App-Secret' => @app_secret }
+      headers: {
+        :'App-Secret' => @app_secret,
+        :'Respoke-SDK' => respoke_sdk_header
+      }
     ) do |faraday|
       faraday.request :json
 
@@ -261,5 +264,10 @@ class Respoke::Client
 
       faraday.adapter Faraday.default_adapter
     end
+  end
+
+  def respoke_sdk_header
+    os = RbConfig::CONFIG['host_os'];
+    "Respoke-Ruby/#{Respoke::VERSION} (#{os}) Ruby/#{RUBY_VERSION}"
   end
 end


### PR DESCRIPTION
This patch adds the Respoke-SDK header to all requests, which
includes the library version, os and os version, and the current
version of Ruby in use.

![screen shot 2015-09-25 at 1 17 49 pm](https://cloud.githubusercontent.com/assets/309219/10109066/485c8b8c-638a-11e5-9817-adc3bdbc6b8f.png)

Related to MER-4340
